### PR TITLE
[PL-1024] - Prospective storyscripter sees logs for the example story

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/aeaf8eec-bc04-429f-95be-85fefcefe938/deploy-status)](https://app.netlify.com/sites/playground-storyscript/deploys)
 [![codecov](https://codecov.io/gh/storyscript/playground/branch/master/graph/badge.svg)](https://codecov.io/gh/storyscript/playground)
-<!-- [![Lighthouse](./.lighthouse-badges/lighthouse.svg)](https://playground.storyscript.io) -->
+[![Lighthouse](./.lighthouse-badges/lighthouse.svg)](https://playground.storyscript.io)
 
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/Storyscript/playground)
@@ -49,8 +49,8 @@ $> yarn playground
 
 [![Lighthouse](./.lighthouse-badges/lighthouse-logo.svg)](https://github.com/GoogleChrome/lighthouse)
 
-<!-- [![Lighthouse Accessibility Badge](./.lighthouse-badges/lighthouse_accessibility.svg)](https://playground.storyscript.io)
+[![Lighthouse Accessibility Badge](./.lighthouse-badges/lighthouse_accessibility.svg)](https://playground.storyscript.io)
 [![Lighthouse Best Practices Badge](./.lighthouse-badges/lighthouse_best-practices.svg)](https://playground.storyscript.io)
 [![Lighthouse Performance Badge](./.lighthouse-badges/lighthouse_performance.svg)](https://playground.storyscript.io)
 [![Lighthouse PWA Badge](./.lighthouse-badges/lighthouse_pwa.svg)](https://playground.storyscript.io)
-[![Lighthouse SEO Badge](./.lighthouse-badges/lighthouse_seo.svg)](https://playground.storyscript.io) -->
+[![Lighthouse SEO Badge](./.lighthouse-badges/lighthouse_seo.svg)](https://playground.storyscript.io)

--- a/src/Playground.vue
+++ b/src/Playground.vue
@@ -8,7 +8,7 @@
   >
     <router-view
       key="route"
-      class="min-h-screen max-w-screen"
+      class="min-h-screen max-w-screen bg-gray-10"
     >
       <s-notification
         v-if="initialized"

--- a/src/Playground.vue
+++ b/src/Playground.vue
@@ -8,7 +8,7 @@
   >
     <router-view
       key="route"
-      class="min-h-screen max-w-screen bg-gray-10"
+      class="min-h-screen max-w-screen"
     >
       <s-notification
         v-if="initialized"

--- a/src/models/StorySample.ts
+++ b/src/models/StorySample.ts
@@ -1,0 +1,3 @@
+export interface IStorySample {
+  logs: string
+}

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,7 +9,7 @@ export default new Router({
   routes: [
     {
       path: '/',
-      component: () => import('@/Playground.vue')
+      component: () => import('@/views/Playground/index.vue')
     },
     {
       path: '*',

--- a/src/samples/counter.ts
+++ b/src/samples/counter.ts
@@ -1,0 +1,23 @@
+import { IStorySample } from '@/models/StorySample'
+
+const counter: IStorySample = {
+  logs: '○ → story deploy\n' +
+  'Compiling Stories…\n' +
+  '✔ Compiled 1 story\n\n' +
+
+  'Deploying app <app name>... ⠹\n' +
+  '  ✔ Version 1 of your app has been queued for deployment.\n\n' +
+
+  '  Waiting for deployment to complete…  ⠏\n' +
+  '  ✔ Configured 1 story\n' +
+  '  - counter.story\n' +
+  '  ✔ Deployed 2 services\n' +
+  '  - http\n' +
+  '  - redis\n' +
+  '  ✔ Created ingress route\n' +
+  '  ✔ Configured logging\n' +
+  '  ✔ Configured health checks\n' +
+  '  ✔ Deployment successful!\n'
+}
+
+export default counter

--- a/src/samples/counter.ts
+++ b/src/samples/counter.ts
@@ -5,10 +5,10 @@ const counter: IStorySample = {
   'Compiling Stories…\n' +
   '✔ Compiled 1 story\n\n' +
 
-  'Deploying app <app name>... ⠹\n' +
+  'Deploying app counter...\n' +
   '  ✔ Version 1 of your app has been queued for deployment.\n\n' +
 
-  '  Waiting for deployment to complete…  ⠏\n' +
+  '  Waiting for deployment to complete…\n' +
   '  ✔ Configured 1 story\n' +
   '  - counter.story\n' +
   '  ✔ Deployed 2 services\n' +

--- a/src/views/Playground/Logs.vue
+++ b/src/views/Playground/Logs.vue
@@ -1,0 +1,31 @@
+<template>
+  <div
+    id="logs"
+    class="overflow-y-auto pt-3 px-6 border-l border-solid border-gray-30"
+  >
+    <s-text
+      p="3"
+      weight="semibold"
+      color="text-gray-100"
+      class="mb-4"
+    >
+      Logs
+    </s-text>
+    <pre class="whitespace-pre-wrap"><code class="text-gray-100 font-body text-sm">{{ logs }}</code></pre>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator'
+import SText from '@/components/Text.vue'
+
+@Component({
+  name: 'Logs',
+  components: {
+    SText
+  }
+})
+export default class Logs extends Vue {
+  @Prop({ type: String, required: true }) readonly logs!: string
+}
+</script>

--- a/src/views/Playground/index.vue
+++ b/src/views/Playground/index.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="min-h-screen">
+    <s-navbar />
+    <div class="min-h-screen-no-navbar flex">
+      <div class="w-2/3">
+        <br>
+        <!-- HERE GOES THE EDITOR -->
+      </div>
+
+      <s-logs
+        class="w-1/3"
+        :logs="payload.logs"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import SNavbar from '@/components/Navbar.vue'
+import SLogs from '@/views/Playground/Logs.vue'
+import { IStorySample } from '@/models/StorySample'
+import sample from '@/samples/counter'
+
+@Component({
+  components: {
+    SNavbar,
+    SLogs
+  }
+})
+export default class Playground extends Vue {
+  private payload: IStorySample = sample
+}
+</script>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -74,8 +74,7 @@ module.exports = {
       },
       spacing: {
         initial: 'initial',
-        'fit-content': 'fit-content',
-        '14': '3.5rem' // 56px
+        'fit-content': 'fit-content'
       },
       boxShadow: {
       }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -74,7 +74,8 @@ module.exports = {
       },
       spacing: {
         initial: 'initial',
-        'fit-content': 'fit-content'
+        'fit-content': 'fit-content',
+        '14': '3.5rem' // 56px
       },
       boxShadow: {
       }

--- a/tests/e2e/logs.e2e.ts
+++ b/tests/e2e/logs.e2e.ts
@@ -1,7 +1,7 @@
 import puppeteer from 'puppeteer'
 const { TEST_URL, puppeteerConfig } = require('./puppeteer.config')
 
-describe('Temporary', () => {
+describe('Logs', () => {
   let page: any
   let browser: any
 
@@ -18,6 +18,8 @@ describe('Temporary', () => {
   })
 
   it('should display', async () => {
-    expect(page.$('#playground')).toBeTruthy()
+    expect.assertions(1)
+    await page.waitForSelector('#logs')
+    expect(await page.$('#logs')).toBeTruthy()
   })
 })

--- a/tests/e2e/percy.e2e.ts
+++ b/tests/e2e/percy.e2e.ts
@@ -1,0 +1,27 @@
+import puppeteer from 'puppeteer'
+import { percySnapshot } from '@percy/puppeteer'
+const { TEST_URL, puppeteerConfig } = require('./puppeteer.config')
+
+describe('Percy screenshots', () => {
+  let page: any
+  let browser: any
+
+  beforeAll(async () => {
+    jest.setTimeout(1000 * 60 * 1)
+    browser = await puppeteer.launch(puppeteerConfig())
+    page = await browser.newPage()
+    page.setBypassCSP(true)
+    await page.goto(TEST_URL)
+  })
+
+  afterAll(() => {
+    browser.close()
+  })
+
+  it('should take a screenshot of the playground page', async () => {
+    expect.assertions(1)
+    await page.waitFor(2000)
+    await percySnapshot(page, 'Playground page')
+    expect(true).toBeTruthy()
+  })
+})

--- a/tests/unit/samples/counter.spec.ts
+++ b/tests/unit/samples/counter.spec.ts
@@ -1,0 +1,11 @@
+import { IStorySample } from '@/models/StorySample'
+import counter from '@/samples/counter'
+
+describe('Counter sample', () => {
+  it('should export logs', () => {
+    expect.assertions(2)
+    const sample: IStorySample = counter
+    expect(sample).toBeDefined()
+    expect(sample.logs).toBeDefined()
+  })
+})

--- a/tests/unit/views/Playground/Logs.spec.ts
+++ b/tests/unit/views/Playground/Logs.spec.ts
@@ -1,0 +1,26 @@
+import { shallowMount, Wrapper } from '@vue/test-utils'
+import Logs from '@/views/Playground/Logs.vue'
+
+describe('Sample Logs', () => {
+  let logs: Wrapper<Logs>
+  let vm: any
+
+  beforeEach(() => {
+    logs = shallowMount(Logs, {
+      propsData: {
+        logs: 'toto'
+      }
+    })
+    vm = logs.vm as any
+  })
+
+  afterEach(() => {
+    logs.destroy()
+  })
+
+  it('should mount with the required props', () => {
+    expect.assertions(2)
+    expect(logs.html()).toBeDefined()
+    expect(vm).toHaveProperty('logs', 'toto')
+  })
+})

--- a/tests/unit/views/Playground/index.spec.ts
+++ b/tests/unit/views/Playground/index.spec.ts
@@ -1,0 +1,21 @@
+import Playground from '@/views/Playground/index.vue'
+import { Wrapper, shallowMount } from '@vue/test-utils'
+
+describe('Playground index', () => {
+  let playground: Wrapper<Playground>
+  let vm: any
+
+  beforeEach(() => {
+    playground = shallowMount(Playground)
+    vm = playground.vm as any
+  })
+
+  afterEach(() => {
+    playground.destroy()
+  })
+
+  it('should mount', () => {
+    expect.assertions(1)
+    expect(playground.html()).toBeDefined()
+  })
+})


### PR DESCRIPTION
As a prospective storyscripter,
When I land on the playground with example,
I am presented with deployment logs for the example story,
So that I can see the automation the platform is providing to me

## Acceptance
**Given** I navigate to the playground
**Then** I am presented with the deployment logs for the example story:

```
○ → story deploy
Compiling Stories…
✔ Compiled 1 story

Deploying app <app name>... ⠹
✔ Version 1 of your app has been queued for deployment.

Waiting for deployment to complete…  ⠏
✔ Configured 1 story
  - counter.story
✔ Deployed 2 services
  - http
  - redis
✔ Created ingress route
✔ Configured logging
✔ Configured health checks
✔ Deployment successful!
```

## Design
![playground-w2](https://user-images.githubusercontent.com/10957531/67297871-c4099e00-f4ea-11e9-8dec-f29ede0fb701.png)

## Notes
https://storyscript.atlassian.net/secure/RapidBoard.jspa?rapidView=5&view=planning&selectedIssue=PL-1024&selectedEpic=PL-1016