### PR TITLE
[PL-1115] - Prospective Storyscripter does not think the logs are a terminal

### DIFF
--- a/src/models/StorySample.ts
+++ b/src/models/StorySample.ts
@@ -3,7 +3,6 @@ export interface IStorySample {
 }
 
 export interface IStoryLogs {
-  cmd: string,
   name: string,
   files: Array<string>,
   services: Array<string>

--- a/src/samples/counter.ts
+++ b/src/samples/counter.ts
@@ -2,7 +2,6 @@ import { IStorySample } from '@/models/StorySample'
 
 const counter: IStorySample = {
   logs: {
-    cmd: 'story deploy',
     name: 'counter',
     files: [
       'counter'

--- a/src/views/Playground/Logs.vue
+++ b/src/views/Playground/Logs.vue
@@ -22,7 +22,7 @@ import SText from '@/components/Text.vue'
 import { IStoryLogs } from '@/models/StorySample'
 import event from '@/event'
 
-const INITIAL_LOGS = '$> '
+const INITIAL_LOGS = ''
 
 @Component({
   name: 'Logs',
@@ -41,8 +41,7 @@ export default class Logs extends Vue {
   mounted () {
     event.$on('deploy', async (cb: Function) => {
       this.output = INITIAL_LOGS
-      await this.writeCmd()
-      await this.sleep(500)
+      await this.sleep(250)
       await this.writeLogs()
       cb()
     })
@@ -50,16 +49,6 @@ export default class Logs extends Vue {
 
   private sleep (time: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, time))
-  }
-
-  private writeCmd (interval: number = 50): Promise<void> {
-    return new Promise(async resolve => {
-      for (let i = 0; i < this.logs.cmd.length; i++) {
-        this.output += this.logs.cmd[i]
-        await this.sleep(interval)
-      }
-      resolve()
-    })
   }
 
   private writeLogs (interval: number = 75): Promise<void> {
@@ -74,20 +63,20 @@ export default class Logs extends Vue {
     }
     const files = () => {
       if (this.logs.files.length > 0) {
-        this.logs.files.forEach(f => {
+        this.logs.files.forEach((f: string) => {
           this.output += `  - ${f}\n`
         })
       }
     }
     const services = () => {
       if (this.logs.services.length > 0) {
-        this.logs.services.forEach(s => {
+        this.logs.services.forEach((s: string) => {
           this.output += `  - ${s}\n`
         })
       }
     }
     const lines = [
-      { delay: 0, text: '\nCompiling Stories' },
+      { delay: 0, text: 'Compiling Stories' },
       { delay: 0, fn: 'tripleDot' },
       { delay: 250, text: `\n✔ Compiled ${this.logs.files.length} story\n\n` },
       { delay: 0, text: `Deploying app ${this.logs.name}` },

--- a/tests/e2e/logs.e2e.ts
+++ b/tests/e2e/logs.e2e.ts
@@ -1,5 +1,4 @@
 import puppeteer from 'puppeteer'
-import { pathToFileURL } from 'url'
 const { TEST_URL, puppeteerConfig } = require('./puppeteer.config')
 
 describe('Logs', () => {
@@ -28,7 +27,7 @@ describe('Logs', () => {
     expect.assertions(1)
     await page.waitForSelector('#logs')
     const logs = await page.$eval('#logs>pre>code', (e: Element) => e.innerHTML)
-    expect(logs).toEqual('$&gt; ')
+    expect(logs).toEqual('')
   })
 
   it('should deplay the good sample after clicking on the deploy button', async () => {

--- a/tests/unit/samples/counter.spec.ts
+++ b/tests/unit/samples/counter.spec.ts
@@ -3,11 +3,10 @@ import counter from '@/samples/counter'
 
 describe('Counter sample', () => {
   it('should export logs', () => {
-    expect.assertions(6)
+    expect.assertions(5)
     const sample: IStorySample = counter
     expect(sample).toBeDefined()
     expect(sample.logs).toBeDefined()
-    expect(sample.logs.cmd).toBeDefined()
     expect(sample.logs.name).toBeDefined()
     expect(sample.logs.files).toBeDefined()
     expect(sample.logs.services).toBeDefined()

--- a/tests/unit/views/Playground/Logs.spec.ts
+++ b/tests/unit/views/Playground/Logs.spec.ts
@@ -35,20 +35,6 @@ describe('Plaground::Logs', () => {
     expect(vm).toHaveProperty('logs', counter.logs)
   })
 
-  describe('.writeCmd()', () => {
-    it('should append the command to the output', async () => {
-      expect.assertions(1)
-      await vm.writeCmd()
-      expect(vm).toHaveProperty('output', '$> story deploy')
-    })
-
-    it('should use a custom timer', async () => {
-      expect.assertions(1)
-      await vm.writeCmd(25)
-      expect(vm).toHaveProperty('output', '$> story deploy')
-    })
-  })
-
   describe('.writeLogs()', () => {
     it('should append the logs to the output', async () => {
       expect.assertions(11)
@@ -106,13 +92,11 @@ describe('Plaground::Logs', () => {
   describe(`event.$on('deploy')`, () => {
     it('should append all the logs', async () => {
       jest.setTimeout(15000)
-      expect.assertions(3)
+      expect.assertions(2)
       const fakeCb = jest.fn()
-      vm.writeCmd = jest.fn()
       vm.writeLogs = jest.fn()
       event.$emit('deploy', fakeCb)
       await new Promise(resolve => setTimeout(resolve, 10000))
-      expect(vm.writeCmd).toHaveBeenCalled()
       expect(vm.writeLogs).toHaveBeenCalled()
       expect(fakeCb).toHaveBeenCalled()
     })


### PR DESCRIPTION
As a prospective storyscripter,
When I click the Deploy button,
I do not see `story deploy` terminal prompt in the logs,
So I don’t think I’m looking at a terminal

## Acceptance

**When** I click the Deploy button
**Then** I see the logs appear incrementally, but with the first line removed:

```
$> story deploy
```

