### PR TITLE
PL-1124 - Allow tips to be skipped

### DIFF
--- a/src/components/Intro.vue
+++ b/src/components/Intro.vue
@@ -1,53 +1,68 @@
 <template>
-  <div
-    v-if="currentTip"
-    class="fixed z-50 top-0 left-0"
-  >
+  <transition name="fade-in">
     <div
-      id="intro-layer"
-      class="bg-gray-100 opacity-25 w-screen h-screen inset-0 absolute"
-    />
-    <!-- s-drop using class before-ml-4 -->
-    <s-drop
-      v-if="!refreshTip"
-      :id="`tip-${currentTip.name}`"
-      ref="tip"
-      bordered
-      class="ml-px mt-px"
-      light
-      mode="click"
-      shadow="sm"
-      :style="`left:${currentTip.x}px;top:${currentTip.y}px`"
-      @close="updateTip"
+      v-if="currentTip"
+      class="fixed z-50 top-0 left-0"
     >
-      <s-icon
-        icon="dot"
-        width="14"
-        height="14"
-        class="text-red-50 animate-ripple p-3 bg-white opacity-75 rounded-full -ml-3 -mt-3"
-        clickable
+      <div
+        id="intro-layer"
+        class="bg-gray-100 opacity-25 w-screen h-screen inset-0 absolute"
       />
-      <template #content>
-        <s-text
-          id="tip-content"
-          p="5"
-          weight="medium"
-          color="text-gray-90"
-          class="max-w-xs w-max-content"
-          v-text="currentTip.text"
+      <!-- s-drop using class before-ml-4 -->
+      <s-drop
+        v-if="!refreshTip"
+        :id="`tip-${currentTip.name}`"
+        ref="tip"
+        bordered
+        class="ml-px mt-px"
+        light
+        mode="click"
+        shadow="sm"
+        :style="`left:${currentTip.x}px;top:${currentTip.y}px`"
+        @close="updateTip"
+      >
+        <s-icon
+          icon="dot"
+          width="14"
+          height="14"
+          class="text-red-50 animate-ripple p-3 bg-white opacity-75 rounded-full -ml-3 -mt-3"
+          clickable
         />
-        <s-text
-          id="next-tip"
-          p="6"
-          weight="semibold"
-          color="text-indigo-60"
-          class="mt-2 cursor-pointer"
-          @click="$refs.tip.hideIfShown()"
-          v-text="currentTipIdx + 1 < tips.length ? 'Next tip' : 'Got it!'"
-        />
-      </template>
-    </s-drop>
-  </div>
+        <template #content>
+          <s-text
+            id="tip-content"
+            p="5"
+            weight="medium"
+            color="text-gray-90"
+            class="max-w-xs w-max-content"
+            v-text="currentTip.text"
+          />
+          <div class="flex items-stretch justify-between mt-2">
+            <s-text
+              id="next-tip"
+              p="6"
+              weight="semibold"
+              color="text-indigo-60"
+              class="cursor-pointer"
+              @click="$refs.tip.hideIfShown()"
+              v-text="currentTipIdx + 1 < tips.length ? 'Next tip' : 'Got it!'"
+            />
+            <s-text
+              v-if="currentTipIdx + 1 < tips.length"
+              id="skip-tips"
+              p="6"
+              weight="semibold"
+              color="text-indigo-60"
+              class="cursor-pointer"
+              @click="$emit('done')"
+            >
+              Skip tips
+            </s-text>
+          </div>
+        </template>
+      </s-drop>
+    </div>
+  </transition>
 </template>
 
 <script lang="ts">
@@ -67,6 +82,7 @@ import SText from '@/components/Text.vue'
 })
 export default class Intro extends Vue {
   @Prop({ type: Array, required: true }) private tips!: IStorySampleTip[]
+  @Prop({ type: Boolean, default: false }) private showAtStartup!: boolean
   private currentTipIdx: number = 0
   private refreshTip: boolean = false
 
@@ -79,14 +95,24 @@ export default class Intro extends Vue {
   private updateTip () {
     this.currentTipIdx++
     if (this.currentTip) {
-      this.$nextTick().then(() => {
-        setTimeout(() => {
-          const tip = this.$refs.tip as any
-          tip.show = true
-        }, 100)
-      })
+      this.$nextTick().then(this.showTip)
     } else {
       this.$emit('done')
+    }
+  }
+
+  private showTip () {
+    setTimeout(() => {
+      const tip = this.$refs.tip as any
+      if (tip) {
+        tip.show = true
+      }
+    }, 100)
+  }
+
+  mounted () {
+    if (this.showAtStartup) {
+      this.$nextTick().then(this.showTip)
     }
   }
 

--- a/src/views/Playground/Logs.vue
+++ b/src/views/Playground/Logs.vue
@@ -35,6 +35,11 @@ export default class Logs extends Vue {
 
   @Prop({ type: Object, required: true }) readonly logs!: IStoryLogs
   @Prop({ type: String, required: true }) readonly name!: string
+  @Prop({ type: Number, default: 250 }) readonly startAfter!: number
+  @Prop({ type: Number, default: 500 }) readonly dotDelay!: number
+
+  // to unify line delay. If this has value >= 0, line.delay is skipped
+  @Prop({ type: Number, default: -1 }) readonly lineDelay!: number
 
   @Getter('getReleasesCount')
   private releasesCount!: number
@@ -42,7 +47,7 @@ export default class Logs extends Vue {
   mounted () {
     event.$on('deploy', async (cb: Function) => {
       this.output = INITIAL_LOGS
-      await this.sleep(250)
+      await this.sleep(this.startAfter)
       await this.writeLogs()
       cb()
     })
@@ -52,11 +57,11 @@ export default class Logs extends Vue {
     return new Promise(resolve => setTimeout(resolve, time))
   }
 
-  private writeLogs (interval: number = 75): Promise<void> {
+  private writeLogs (): Promise<void> {
     const tripleDot = () => {
       return new Promise(async resolve => {
         for (let i in [1, 2, 3]) {
-          await this.sleep(500)
+          await this.sleep(this.dotDelay)
           this.output += '.'
         }
         resolve()
@@ -110,7 +115,7 @@ export default class Logs extends Vue {
               break
           }
         }
-        await this.sleep((l as any).delay)
+        await this.sleep(this.lineDelay >= 0 ? this.lineDelay : (l as any).delay)
       }
       resolve()
     })

--- a/src/views/Playground/index.vue
+++ b/src/views/Playground/index.vue
@@ -36,6 +36,7 @@
     <s-intro
       v-if="payload.tips && isIntro"
       :tips="payload.tips"
+      show-at-startup
       @done="isIntro = false"
     />
   </div>

--- a/src/views/index.vue
+++ b/src/views/index.vue
@@ -23,7 +23,8 @@ export default class Layout extends Vue {
   private isIntro: boolean = true
 
   mounted () {
-    if (!this.$route.params.hasOwnProperty('sample') && !this.$route.path.includes('welcome')) {
+    if ((!this.$route || !this.$route.params || !('sample' in this.$route.params)) &&
+      (this.$route && this.$route.path && !this.$route.path.includes('welcome'))) {
       this.$router.push({ name: 'playground', params: { sample: 'counter' }, query: this.$route.query })
     }
     this.welcome = this.$route.name === 'welcome'

--- a/tests/e2e/intro.e2e.ts
+++ b/tests/e2e/intro.e2e.ts
@@ -37,6 +37,7 @@ describe('Welcome', () => {
       expect(await page.$eval('#tip-content', (e: Element) => e.innerHTML.trim())).toEqual(t.text)
       await page.click('#next-tip')
     }
+    await page.waitFor(300)
     expect(await page.$('#intro-layer')).toBeNull()
   })
 })

--- a/tests/unit/components/Intro.spec.ts
+++ b/tests/unit/components/Intro.spec.ts
@@ -27,7 +27,8 @@ describe('Intro.vue', () => {
             text: 'content',
             x: 0,
             y: 0
-          }]
+          }],
+          showAtStartup: true
         }
       })
       vm = view.vm as any
@@ -47,20 +48,29 @@ describe('Intro.vue', () => {
       })
     })
 
-    it('updateTip', async () => {
-      expect.assertions(4)
+    it('showTip', async () => {
+      expect.assertions(2)
       vm.$refs.tip = { show: false }
-      expect(vm).toHaveProperty('currentTipIdx', 0)
-      vm.updateTip()
-      expect(vm).toHaveProperty('currentTipIdx', 1)
+      expect(vm.$refs.tip).toHaveProperty('show', false)
+      vm.showTip()
       await new Promise(resolve => {
         setTimeout(() => {
           expect(vm.$refs.tip).toHaveProperty('show', true)
-          vm.updateTip()
-          expect(view.emitted().done).toBeTruthy()
           resolve()
-        }, 150)
+        }, 200)
       })
+    })
+
+    it('updateTip', async () => {
+      expect.assertions(4)
+      vm.showTip = jest.fn()
+      expect(vm).toHaveProperty('currentTipIdx', 0)
+      vm.updateTip()
+      expect(vm).toHaveProperty('currentTipIdx', 1)
+      await vm.$nextTick()
+      expect(vm.showTip).toHaveBeenCalled()
+      vm.updateTip()
+      expect(view.emitted().done).toBeTruthy()
     })
   })
 })

--- a/tests/unit/views/Playground/Logs.spec.ts
+++ b/tests/unit/views/Playground/Logs.spec.ts
@@ -11,14 +11,17 @@ localVue.use(Vuex)
 describe('Plaground::Logs', () => {
   let logs: Wrapper<Logs>
   let vm: any
-    let store: Store<any>
+  let store: Store<any>
 
   beforeEach(() => {
     store = new Vuex.Store(StoreLogs)
     logs = shallowMount(Logs, {
       propsData: {
         logs: counter.logs,
-        name: counter.name
+        name: counter.name,
+        startAfter: 0,
+        dotDelay: 0,
+        lineDelay: 0
       },
       store,
       localVue
@@ -37,25 +40,9 @@ describe('Plaground::Logs', () => {
   })
 
   describe('.writeLogs()', () => {
-    it('should append the logs to the output', async () => {
-      expect.assertions(11)
-      await vm.writeLogs()
-      expect(/Compiling Stories\.\.\./.test(vm.output)).toBeTruthy()
-      expect(/✔ Compiled [\d]+ story/.test(vm.output)).toBeTruthy()
-      expect(/Deploying app [\w]{1,25}\.\.\./.test(vm.output)).toBeTruthy()
-      expect(/✔ Version [\d]+ of your app has been queued for deployment\./.test(vm.output)).toBeTruthy()
-      expect(/Waiting for deployment to complete\.\.\./.test(vm.output)).toBeTruthy()
-      expect(/✔ Configured [\d]+ story/.test(vm.output)).toBeTruthy()
-      expect(/✔ Deployed [\d]+ services/.test(vm.output)).toBeTruthy()
-      expect(/✔ Created ingress route/.test(vm.output)).toBeTruthy()
-      expect(/✔ Configured logging/.test(vm.output)).toBeTruthy()
-      expect(/✔ Configured health checks/.test(vm.output)).toBeTruthy()
-      expect(/✔ Deployment successful!/.test(vm.output)).toBeTruthy()
-    })
-
-    it('should use a custom timer', async () => {
+    it('should append the logs', async () => {
       expect.assertions(14)
-      await vm.writeLogs(25)
+      await vm.writeLogs()
       expect(/Compiling Stories\.\.\./.test(vm.output)).toBeTruthy()
       expect(/✔ Compiled 1 story/.test(vm.output)).toBeTruthy()
       expect(/Deploying app [\w]{1,25}\.\.\./.test(vm.output)).toBeTruthy()
@@ -88,16 +75,31 @@ describe('Plaground::Logs', () => {
       expect(/- http/.test(vm.output)).toBeFalsy()
       expect(/- redis/.test(vm.output)).toBeFalsy()
     })
+
+    it('should write with actual line delay', async () => {
+      const view = shallowMount(Logs, {
+        propsData: {
+          logs: counter.logs,
+          name: counter.name,
+          startAfter: 0,
+          dotDelay: 0
+        },
+        store,
+        localVue
+      })
+      const vvm = view.vm as any
+      expect(vvm).toHaveProperty('lineDelay', -1)
+      view.destroy()
+    })
   })
 
   describe(`event.$on('deploy')`, () => {
     it('should append all the logs', async () => {
-      jest.setTimeout(15000)
       expect.assertions(2)
       const fakeCb = jest.fn()
       vm.writeLogs = jest.fn()
       event.$emit('deploy', fakeCb)
-      await new Promise(resolve => setTimeout(resolve, 10000))
+      await new Promise(resolve => setTimeout(resolve, 100))
       expect(vm.writeLogs).toHaveBeenCalled()
       expect(fakeCb).toHaveBeenCalled()
     })

--- a/tests/unit/views/Playground/index.spec.ts
+++ b/tests/unit/views/Playground/index.spec.ts
@@ -1,22 +1,30 @@
 import Playground from '@/views/Playground/index.vue'
-import { Wrapper, shallowMount, createLocalVue } from '@vue/test-utils'
+import { Wrapper, shallowMount } from '@vue/test-utils'
 import samples from '@/samples'
-import VueRouter from 'vue-router'
 
 describe('Playground index', () => {
   let playground: Wrapper<Playground>
   let vm: any
-  let router = new VueRouter({
-    routes: [{
-      path: '*',
-      name: 'not-found'
-    }]
-  })
-
-  const localVue = createLocalVue()
-  localVue.use(VueRouter)
 
   beforeEach(() => {
+    playground = shallowMount(Playground, {
+      stubs: {
+        RouterView: true
+      },
+      mocks: {
+        $route: {
+          path: '/example/test'
+        },
+        $router: {
+          push: jest.fn(),
+          replace: jest.fn()
+        }
+      },
+      propsData: {
+        sample: ''
+      }
+    })
+    vm = playground.vm as any
   })
 
   afterEach(() => {
@@ -24,54 +32,6 @@ describe('Playground index', () => {
   })
 
   it('should mount', () => {
-    playground = shallowMount(Playground, {
-      propsData: {
-        sample: ''
-      }
-    })
-    vm = playground.vm as any
-
-    expect.assertions(1)
-    expect(playground.html()).toBeDefined()
-  })
-
-  it('should mount', () => {
-    const routes = [
-      {
-        name: 'welcome',
-        path: '/welcome'
-      },
-      {
-        name: 'playground',
-        path: '/:sample'
-      },
-      {
-        name: 'not-found',
-        path: '*'
-      }
-    ]
-    const $route = {
-      path: '/example/test'
-    }
-    router = new VueRouter({
-      routes: [...routes]
-    })
-
-    playground = shallowMount(Playground, {
-      localVue,
-      router,
-      stubs: [
-        'router-view'
-      ],
-      mocks: {
-        $route
-      },
-      propsData: {
-        sample: 'test'
-      }
-    })
-    vm = playground.vm as any
-
     expect.assertions(1)
     expect(playground.html()).toBeDefined()
   })
@@ -79,9 +39,16 @@ describe('Playground index', () => {
   it('should skip intro', () => {
     expect.assertions(1)
     const view = shallowMount(Playground, {
+      propsData: {
+        sample: 'not-a-sample'
+      },
       mocks: {
         $route: {
           query: { skipIntro: 'true' }
+        },
+        $router: {
+          push: jest.fn(),
+          replace: jest.fn()
         }
       }
     })
@@ -91,16 +58,26 @@ describe('Playground index', () => {
 
   describe('.setPayload(string)', () => {
     it('should set the payload', () => {
-      playground = shallowMount(Playground, {
+      const view = shallowMount(Playground, {
         propsData: {
           sample: 'counter'
+        },
+        mocks: {
+          $route: {
+            query: { skipIntro: 'true' }
+          },
+          $router: {
+            push: jest.fn(),
+            replace: jest.fn()
+          }
         }
       })
-      vm = playground.vm as any
+      const vvm = view.vm as any
 
       expect.assertions(1)
-      vm.setPayload('counter')
-      expect(vm).toHaveProperty('payload', samples['counter'])
+      vvm.setPayload('counter')
+      expect(vvm).toHaveProperty('payload', samples['counter'])
+      view.destroy()
     })
   })
 })

--- a/tests/unit/views/index.spec.ts
+++ b/tests/unit/views/index.spec.ts
@@ -1,17 +1,12 @@
 import Index from '@/views/index.vue'
-import { Wrapper, shallowMount, createLocalVue } from '@vue/test-utils'
-import VueRouter from 'vue-router'
+import { Wrapper, shallowMount } from '@vue/test-utils'
 import event from '@/event'
-
-const localVue = createLocalVue()
-localVue.use(VueRouter)
 
 describe('index.vue', () => {
   let view: Wrapper<Index>
   let vm: any
-  let router: VueRouter
 
-  beforeEach(() => {})
+  beforeEach(() => { })
 
   afterEach(() => {
     view.destroy()
@@ -19,31 +14,13 @@ describe('index.vue', () => {
 
   describe('default routing', () => {
     beforeEach(() => {
-      const routes = [
-        {
-          name: 'welcome',
-          path: '/welcome'
-        },
-        {
-          name: 'playground',
-          path: '/:sample'
-        }
-      ]
-      const $route = {
-        path: '/welcome'
-      }
-      router = new VueRouter({
-        routes: [...routes]
-      })
-
       view = shallowMount(Index, {
-        localVue,
-        router,
-        stubs: [
-          'router-view'
-        ],
+        stubs: {
+          RouterView: true
+        },
         mocks: {
-          $route
+          $route: { params: {}, path: '/' },
+          $router: { push: jest.fn() }
         }
       })
       vm = view.vm as any
@@ -56,11 +33,32 @@ describe('index.vue', () => {
 
     describe(`event.$on('welcome')`, () => {
       it(`should register an eventListener for 'welcome'`, () => {
-        expect.assertions(1)
+        expect.assertions(2)
 
         event.$emit('welcome', true)
         expect(vm).toHaveProperty('welcome', true)
+        expect(vm).toHaveProperty('isIntro', true)
       })
+    })
+
+    it(`isIntro should be false`, async () => {
+      expect.assertions(1)
+
+      const idxView = await shallowMount(Index, {
+        stubs: {
+          RouterView: true
+        },
+        mocks: {
+          $route: {
+            query: {
+              skipIntro: 'true'
+            }
+          }
+        }
+      })
+      const ivm = idxView.vm as any
+      expect(ivm).toHaveProperty('isIntro', false)
+      idxView.destroy()
     })
   })
 })


### PR DESCRIPTION
- [x] add skip tips
- [x] refactor logs test -- 24s -> < 3s (total to 7s on my laptop)
- [x] refactor other tests to remove warnings on routing
- [x] add skip unit testing

___
As a prospective storyscripter,
When I navigate to the playground,
I should be able to skip tips,
So I don’t have to go through them all again if I don’t want to

### Acceptance
**Given** I navigate to the platform
**When** I see the first tip, I can click a link that says “skip tips”
**Then** I am shown no more tips