### PR TITLE
PL-1113 - Prospective storyscripter gets the story autotyped

### DIFF
--- a/src/store/modules/Samples.ts
+++ b/src/store/modules/Samples.ts
@@ -1,0 +1,16 @@
+const state = {
+  written: []
+}
+
+const getters = {
+  getSamplesWritten: (state: any) => state.written,
+  isSampleWritten: (state: any) => (sample: string) => state.written.includes(sample)
+}
+
+const mutations = {
+  writeSample: (state: any, sample: string) => !state.written.includes(sample) && state.written.push(sample)
+}
+
+export default {
+  state, getters, mutations
+}

--- a/src/views/Playground/index.vue
+++ b/src/views/Playground/index.vue
@@ -23,7 +23,7 @@
         </s-text>
       </div>
       <monaco-editor
-        v-model="payload.code"
+        v-model="code"
         class="w-full h-full"
         :options="options"
       />
@@ -43,6 +43,7 @@
 </template>
 
 <script lang="ts">
+import { Getter, Mutation } from 'vuex-class'
 import { Component, Vue, Prop, Watch, Emit } from 'vue-property-decorator'
 import SLogs from '@/views/Playground/Logs.vue'
 import { IStorySample } from '@/models/StorySample'
@@ -64,8 +65,13 @@ import SIntro from '@/components/Intro.vue'
 export default class Playground extends Vue {
   @Prop({ type: String, default: 'counter' }) readonly sample!: string
 
+  @Getter('isSampleWritten') isSampleWritten!: (sample: string) => boolean
+
+  @Mutation('writeSample') writeSample!: (sample: string) => void
+
   private payload: IStorySample = samples[samples.hasOwnProperty(this.sample) ? this.sample : 'counter' || 'counter']
   private isIntro: boolean = false
+  private code: string = ''
 
   @Emit('introChange')
   @Watch('isIntro') private onIntroChange (): boolean {
@@ -81,6 +87,19 @@ export default class Playground extends Vue {
 
   public setPayload (sample: string) {
     this.payload = samples[sample]
+    this.writeCode()
+  }
+
+  public async writeCode () {
+    if (!this.isSampleWritten(this.sample)) {
+      for (let c of this.payload.code) {
+        this.code += c
+        await new Promise(resolve => setTimeout(resolve, Math.random()))
+      }
+      this.writeSample(this.sample)
+    } else {
+      this.code = this.payload.code
+    }
   }
 
   created () {

--- a/tests/unit/store/modules/Samples.spec.ts
+++ b/tests/unit/store/modules/Samples.spec.ts
@@ -1,0 +1,42 @@
+import Vuex, { Store } from 'vuex'
+import { createLocalVue } from '@vue/test-utils'
+import Samples from '@/store/modules/Samples'
+
+const localVue = createLocalVue()
+
+localVue.use(Vuex)
+
+describe('Store::Samples', () => {
+  let store: Store<any>
+
+  beforeEach(() => {
+    store = new Vuex.Store(Samples)
+    store.state.written = []
+  })
+
+  describe('getters', () => {
+    it('getSamplesWritten', () => {
+      expect.assertions(1)
+      const value = store.getters.getSamplesWritten
+      expect(value).toEqual([])
+    })
+    it('isSampleWritten', () => {
+      expect.assertions(2)
+      let value = store.getters.isSampleWritten('hello')
+      expect(value).toEqual(false)
+      store.commit('writeSample', 'hello')
+      value = store.getters.isSampleWritten('hello')
+      expect(value).toEqual(true)
+    })
+  })
+
+  describe('mutations', () => {
+    it('writeSample', () => {
+      expect.assertions(2)
+      expect(store.state.written.length).toEqual(0)
+      store.commit('writeSample', 'hello')
+      store.commit('writeSample', 'hello')
+      expect(store.state.written.length).toEqual(1)
+    })
+  })
+})

--- a/tests/unit/views/Playground/index.spec.ts
+++ b/tests/unit/views/Playground/index.spec.ts
@@ -1,12 +1,19 @@
 import Playground from '@/views/Playground/index.vue'
-import { Wrapper, shallowMount } from '@vue/test-utils'
+import { Wrapper, shallowMount, createLocalVue } from '@vue/test-utils'
+import StoreSamples from '@/store/modules/Samples'
+import Vuex, { Store } from 'vuex'
 import samples from '@/samples'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
 
 describe('Playground index', () => {
   let playground: Wrapper<Playground>
   let vm: any
+  let store: Store<any>
 
   beforeEach(() => {
+    store = new Vuex.Store(StoreSamples)
     playground = shallowMount(Playground, {
       stubs: {
         RouterView: true
@@ -22,7 +29,9 @@ describe('Playground index', () => {
       },
       propsData: {
         sample: ''
-      }
+      },
+      store,
+      localVue
     })
     vm = playground.vm as any
   })
@@ -50,14 +59,16 @@ describe('Playground index', () => {
           push: jest.fn(),
           replace: jest.fn()
         }
-      }
+      },
+      store,
+      localVue
     })
     expect(view.vm).toHaveProperty('isIntro', false)
     view.destroy()
   })
 
   describe('.setPayload(string)', () => {
-    it('should set the payload', () => {
+    it('should set the payload', async () => {
       const view = shallowMount(Playground, {
         propsData: {
           sample: 'counter'
@@ -70,13 +81,44 @@ describe('Playground index', () => {
             push: jest.fn(),
             replace: jest.fn()
           }
-        }
+        },
+        store,
+        localVue
       })
       const vvm = view.vm as any
 
       expect.assertions(1)
       vvm.setPayload('counter')
       expect(vvm).toHaveProperty('payload', samples['counter'])
+      view.destroy()
+    })
+  })
+
+  describe('.writeCode()', () => {
+    it('should write code then return payload code', async () => {
+      const view = shallowMount(Playground, {
+        propsData: {
+          sample: 'counter'
+        },
+        mocks: {
+          $route: {
+            query: { skipIntro: 'true' }
+          },
+          $router: {
+            push: jest.fn(),
+            replace: jest.fn()
+          }
+        },
+        store,
+        localVue
+      })
+      const vvm = view.vm as any
+
+      expect.assertions(2)
+      await vvm.writeCode()
+      expect(store.state).toHaveProperty('written', ['counter'])
+      await vvm.writeCode()
+      expect(vvm.isSampleWritten(vvm.sample)).toBeTruthy()
       view.destroy()
     })
   })


### PR DESCRIPTION
- [x] add typing method
- [x] add unit testing
- [x] add sample module in store
- [x] write if sample name is not stored
- [ ] add e2e test

___
As a prospective storyscripter,
I see the script autotype incrementally,
So I can parse the script bit by bit, rather than as a large block

### Acceptance
**Given** I open an example
**Then** I see the script incrementally start to appear as if being typed
**And** When I navigate away and return to the page
**Then** I don’t see it being typed again

___

**Note**
@williammartin should this be persistant ? I understand "navigate away" as going to the welcome page and going back to the playground. Is that the case ? Or by "navigate away" you mean closing and reopening the playground ?